### PR TITLE
Fix cmake compilation error in Ubuntu 18.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ CMakeCache.txt
 libmiracle-shared.a
 install_manifest.txt
 .vimrc
+build

--- a/res/dispctl.vala
+++ b/res/dispctl.vala
@@ -804,7 +804,7 @@ int main(string[]? argv)
 
 
 	Application app = new DispCtl();
-	app.set_default();
+	app.set_default(app);
 
 	Sigint.add_watch((app as DispCtl).stop_wireless_display);
 


### PR DESCRIPTION
I had the following error in compiling it in Ubuntu 18.04 with cmake:
```
miraclecast/res/dispctl.vala:807.2-807.18: error: 1 missing arguments for `void GLib.Application.set_default (GLib.Application?)'
	app.set_default();
```